### PR TITLE
refactor: edit authGuard payLoad and response data of Auth

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -23,7 +23,7 @@ export class AuthGuard implements CanActivate {
         secret: jwtConstants.secret,
       });
 
-      request['userId'] = payload.userId;
+      request['userEmail'] = payload.userEmail;
     } catch {
       throw new UnauthorizedException(['토큰이 만료되었습니다.']);
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -52,15 +52,15 @@ export class AuthService {
     }
 
     const payload = {
-      sub: user.id,
+      userEmail: user.email,
     };
 
     const userData = {
-      email: user.email,
-      name: user.name,
-      univ: user.univ,
-      department: user.department,
-      admissionDate: user.admissionDate,
+        email: user.email,
+        name: user.name,
+        univ: user.univ,
+        department: user.department,
+        admissionDate: user.admissionDate,
       expectedGraduationDate: user.admissionDate,
     };
 
@@ -98,7 +98,7 @@ export class AuthService {
     await this.cacheManager.del(email);
     return {
       statusCode: HttpStatus.CREATED,
-      message: [`인증번호를 올바르게 입력했습니다.`],
+        message: [`인증번호를 올바르게 입력했습니다.`],
     };
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -27,15 +27,14 @@ export class AuthService {
     await this.usersService.createUser(signUpDto);
     const user = await this.usersService.findByEmail(signUpDto.email);
 
-    const data = {
-      email: user.email,
-      createdAt: user.createdAt,
-      updatedAt: user.updatedAt,
-    };
-
     return {
       statusCode: HttpStatus.CREATED,
-      data: data,
+      data: {
+        message: ['정상적으로 회원가입 되었습니다.'],
+        email: user.email,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      },
     };
   }
 
@@ -55,19 +54,18 @@ export class AuthService {
       userEmail: user.email,
     };
 
-    const userData = {
+    return {
+      statusCode: HttpStatus.OK,
+      data: {
+        message: ['정상적으로 로그인되었습니다.'],
+        accessToken: await this.jwtService.signAsync(payload),
         email: user.email,
         name: user.name,
         univ: user.univ,
         department: user.department,
         admissionDate: user.admissionDate,
-      expectedGraduationDate: user.admissionDate,
-    };
-
-    return {
-      statusCode: HttpStatus.OK,
-      accessToken: await this.jwtService.signAsync(payload),
-      data: userData,
+        expectedGraduationDate: user.expectedGraduationDate,
+      },
     };
   }
 
@@ -83,7 +81,9 @@ export class AuthService {
       await this.cacheManager.set(email, code, 300 * 1000);
       return {
         statusCode: HttpStatus.CREATED,
-        message: ['이메일을 전송했습니다.'],
+        data: {
+          message: [`${email}로 인증번호를 전송했습니다.`],
+        },
       };
     } catch (e) {
       throw new InternalServerErrorException([
@@ -98,7 +98,9 @@ export class AuthService {
     await this.cacheManager.del(email);
     return {
       statusCode: HttpStatus.CREATED,
+      data: {
         message: [`인증번호를 올바르게 입력했습니다.`],
+      },
     };
   }
 }


### PR DESCRIPTION
- Payload를 기존에는 userId로 했었는데, userEmail로 수정했습니다.
- 요청에 성공했을 경우의 Reponse 데이터 값을 아래와 같이 통일시켰습니다.

```
{
    "statusCode": HttpStatus.Code,
    "data": {
        "message": [
            string
        ],
    }
}
```