### PR TITLE
refactor: change date to string & edit createUserLogic 

### DIFF
--- a/src/records/entities/record.entity.ts
+++ b/src/records/entities/record.entity.ts
@@ -27,10 +27,10 @@ export class RecordEntity extends CommonEntity {
   content: string;
 
   @Column({ nullable: false })
-  start: Date;
+  start: string;
 
   @Column({ nullable: false })
-  end: Date;
+  end: string;
 
   @Column({ nullable: true })
   impression: string;

--- a/src/records/records.service.ts
+++ b/src/records/records.service.ts
@@ -28,8 +28,6 @@ export class RecordsService {
       id: uuid(),
       author: user,
       ...createRecordDto,
-      start: new Date(createRecordDto.start),
-      end: new Date(createRecordDto.end),
       createdAt: now,
       updatedAt: now,
     });
@@ -111,8 +109,8 @@ export class RecordsService {
     post.title = updateRecordDto.title;
     post.content = updateRecordDto.content;
     post.impression = updateRecordDto.impression;
-    post.start = new Date(updateRecordDto.start);
-    post.end = new Date(updateRecordDto.end);
+    post.start = updateRecordDto.start;
+    post.end = updateRecordDto.end;
 
     await this.recordsRepository.save(post);
 

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -29,10 +29,10 @@ export class UserEntity {
   department: string;
 
   @Column({ nullable: false })
-  admissionDate: Date;
+  admissionDate: string;
 
   @Column({ nullable: false })
-  expectedGraduationDate: Date;
+  expectedGraduationDate: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -17,17 +17,11 @@ export class UsersService {
 
   async createUser(createUserDto: createUserDto) {
     const now = new Date();
-    const user = new UserEntity();
-
-    user.email = createUserDto.email;
-    user.password = createUserDto.password;
-    user.name = createUserDto.name;
-    user.univ = createUserDto.univ;
-    user.department = createUserDto.department;
-    user.admissionDate = createUserDto.admissionDate;
-    user.expectedGraduationDate = createUserDto.expectedGraduationDate;
-    user.createdAt = now;
-    user.updatedAt = now;
+    const user = this.usersRepository.create({
+      ...createUserDto,
+      createdAt: now,
+      updatedAt: now,
+    });
 
     if (user.expectedGraduationDate < user.admissionDate) {
       throw new ConflictException(['졸업 예정일이 입학일 보다 빠릅니다.']);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -3,7 +3,6 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { v1 as uuid } from 'uuid';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserEntity } from './entities/user.entity';
@@ -25,10 +24,8 @@ export class UsersService {
     user.name = createUserDto.name;
     user.univ = createUserDto.univ;
     user.department = createUserDto.department;
-    user.admissionDate = new Date(createUserDto.admissionDate);
-    user.expectedGraduationDate = new Date(
-      createUserDto.expectedGraduationDate,
-    );
+    user.admissionDate = createUserDto.admissionDate;
+    user.expectedGraduationDate = createUserDto.expectedGraduationDate;
     user.createdAt = now;
     user.updatedAt = now;
 


### PR DESCRIPTION
- 프론트 요청에 따라 입학날짜, 졸업예정날짜, 활동 시작 날짜, 활동 끝난 날짜 형태를 "2022-01-30" 형태로 수정
- 기존의 createUser 로직 -> typeorm의 create 함수를 사용한 로직으로 수정